### PR TITLE
Fix: Use Windows authentication instead of hardcoded SQL credentials

### DIFF
--- a/Modules/SQLUpgrade.Connection.psm1
+++ b/Modules/SQLUpgrade.Connection.psm1
@@ -36,11 +36,10 @@ function Test-InstanceConnectivity {
     )
     
     try {
-        # Use TrustServerCertificate and SQL credentials for container connections
-        $sqlCredential = New-Object System.Management.Automation.PSCredential("sa", (ConvertTo-SecureString "YourStrong@Passw0rd" -AsPlainText -Force))
-        $connection = Connect-DbaInstance -SqlInstance $Instance -SqlCredential $sqlCredential -TrustServerCertificate -ConnectTimeout 10
+        # Use Windows authentication by default (Integrated Security)
+        $connection = Connect-DbaInstance -SqlInstance $Instance -ConnectTimeout 10
         if ($connection) {
-            Write-UpgradeLog -Message "Successfully connected to $Instance" -LogFile $LogFile -ErrorLogFile $ErrorLogFile -WriteToEventLog
+            Write-UpgradeLog -Message "Successfully connected to $Instance using Windows authentication" -LogFile $LogFile -ErrorLogFile $ErrorLogFile -WriteToEventLog
             return $connection
         }
     } catch {


### PR DESCRIPTION
## Summary

Removes hardcoded SQL Server `sa` credentials from `Test-InstanceConnectivity` function and switches to Windows authentication (Integrated Security) by default.

**Before**: Function forced SQL authentication with hardcoded `sa/YourStrong@Passw0rd` credentials
**After**: Function uses Windows authentication via the current user's credentials

## Review & Testing Checklist for Human

- [ ] **Verify integration tests still pass** - The removed code had a comment "for container connections" suggesting it was added for Docker-based testing. Check if `Tests/SQLUpgrade.Integration.Tests.ps1` or any CI pipelines depend on SQL auth with these credentials.
- [ ] **Test against actual SQL Server** - Run `Start-SQLServerUpgrade.ps1` against a real SQL Server instance using Windows authentication to confirm connectivity works.
- [ ] **Consider if `-TrustServerCertificate` removal causes issues** - This flag was also removed; verify this doesn't cause certificate validation failures in your environment.

**Recommended test plan**: 
1. Run `.\Start-SQLServerUpgrade.ps1 -SourceInstance "YourServer" -TargetInstance "YourServer2022" -Databases "All" -WhatIf` with your Windows credentials
2. Verify successful connection message shows "using Windows authentication"

### Notes

- If you need SQL authentication support in the future, consider adding an optional `-SqlCredential` parameter (similar to how `Start-DbaMigration.ps1` handles it) rather than hardcoding credentials.
- Link to Devin run: https://app.devin.ai/sessions/f044a9d1d7104fc98b0820200d35ca03
- Requested by: karim_attaleb01@yahoo.fr (@karim-attaleb)