### PR TITLE
Fix: Correct dbatools cmdlet names for DBCC CHECKDB and server triggers

### DIFF
--- a/Modules/SQLUpgrade.Migration.psm1
+++ b/Modules/SQLUpgrade.Migration.psm1
@@ -309,11 +309,11 @@ try {
     Write-Host "Updated statistics for database: $DatabaseName" -ForegroundColor Cyan
     
     # Run DBCC CHECKDB
-    `$checkResult = Invoke-DbaDbccCheckdb -SqlInstance `$targetConn -Database '$DatabaseName'
-    if (`$checkResult.Status -eq "Success") {
+    try {
+        Invoke-DbaQuery -SqlInstance `$targetConn -Database '$DatabaseName' -Query "DBCC CHECKDB([$DatabaseName]) WITH NO_INFOMSGS" -EnableException
         Write-Host "DBCC CHECKDB completed successfully for database: $DatabaseName" -ForegroundColor Green
-    } else {
-        Write-Warning "DBCC CHECKDB found issues in database: $DatabaseName"
+    } catch {
+        Write-Warning "DBCC CHECKDB found issues in database: $DatabaseName - `$(`$_.Exception.Message)"
     }
     
     Write-Host "Post-migration tasks completed for database: $DatabaseName" -ForegroundColor Green
@@ -582,7 +582,7 @@ Write-Host "Server objects migration script completed" -ForegroundColor Green
             Write-UpgradeLog -Message "Migrating server triggers" -LogFile $LogFile -ErrorLogFile $ErrorLogFile
             if (-not $WhatIfMode) {
                 try {
-                    Copy-DbaServerTrigger -Source $SourceConnection -Destination $TargetConnection
+                    Copy-DbaInstanceTrigger -Source $SourceConnection -Destination $TargetConnection
                     Write-UpgradeLog -Message "Successfully migrated server triggers" -LogFile $LogFile -ErrorLogFile $ErrorLogFile
                 } catch {
                     Write-UpgradeLog -Message "Error migrating server triggers: $($_.Exception.Message)" -Level "Warning" -LogFile $LogFile -ErrorLogFile $ErrorLogFile

--- a/Modules/SQLUpgrade.PostUpgrade.psm1
+++ b/Modules/SQLUpgrade.PostUpgrade.psm1
@@ -52,11 +52,11 @@ function Invoke-PostUpgradeTasks {
             # Database Integrity Check
             Write-UpgradeLog -Message "Running DBCC CHECKDB for $dbName" -LogFile $LogFile -ErrorLogFile $ErrorLogFile
             if (-not $WhatIfMode) {
-                $checkResult = Invoke-DbaDbccCheckdb -SqlInstance $TargetConnection -Database $dbName
-                if ($checkResult.Status -eq "Success") {
+                try {
+                    Invoke-DbaQuery -SqlInstance $TargetConnection -Database $dbName -Query "DBCC CHECKDB([$dbName]) WITH NO_INFOMSGS" -EnableException
                     Write-UpgradeLog -Message "DBCC CHECKDB completed successfully for $dbName" -LogFile $LogFile -ErrorLogFile $ErrorLogFile -WriteToEventLog
-                } else {
-                    Write-UpgradeLog -Message "DBCC CHECKDB found issues in $dbName" -Level "Warning" -LogFile $LogFile -ErrorLogFile $ErrorLogFile -WriteToEventLog
+                } catch {
+                    Write-UpgradeLog -Message "DBCC CHECKDB found issues in $dbName : $($_.Exception.Message)" -Level "Warning" -LogFile $LogFile -ErrorLogFile $ErrorLogFile -WriteToEventLog
                 }
             } else {
                 Write-UpgradeLog -Message "[WHATIF] Would run DBCC CHECKDB for $dbName" -LogFile $LogFile -ErrorLogFile $ErrorLogFile

--- a/Start-SQLServerUpgrade.ps1
+++ b/Start-SQLServerUpgrade.ps1
@@ -318,11 +318,11 @@ Write-Host "Starting SQL Server instance upgrade migration" -ForegroundColor Gre
 Write-Host "Running post-upgrade tasks for database: $dbName" -ForegroundColor Yellow
 
 # Check database integrity
-`$checkResult = Invoke-DbaDbccCheckdb -SqlInstance `$targetConn -Database '$dbName'
-if (`$checkResult.Status -eq "Success") {
+try {
+    Invoke-DbaQuery -SqlInstance `$targetConn -Database '$dbName' -Query "DBCC CHECKDB([$dbName]) WITH NO_INFOMSGS" -EnableException
     Write-Host "DBCC CHECKDB completed successfully for $dbName" -ForegroundColor Green
-} else {
-    Write-Warning "DBCC CHECKDB found issues in $dbName"
+} catch {
+    Write-Warning "DBCC CHECKDB found issues in $dbName - `$(`$_.Exception.Message)"
 }
 
 # Update compatibility level to SQL Server 2022 (160)

--- a/Tests/SQLUpgrade.Tests.ps1
+++ b/Tests/SQLUpgrade.Tests.ps1
@@ -417,11 +417,11 @@ try {
     Write-Host "Updated statistics for database: TestDB" -ForegroundColor Cyan
     
     # Run DBCC CHECKDB
-    `$checkResult = Invoke-DbaDbccCheckdb -SqlInstance `$targetConn -Database 'TestDB'
-    if (`$checkResult.Status -eq "Success") {
+    try {
+        Invoke-DbaQuery -SqlInstance `$targetConn -Database 'TestDB' -Query "DBCC CHECKDB([TestDB]) WITH NO_INFOMSGS" -EnableException
         Write-Host "DBCC CHECKDB completed successfully for database: TestDB" -ForegroundColor Green
-    } else {
-        Write-Warning "DBCC CHECKDB found issues in database: TestDB"
+    } catch {
+        Write-Warning "DBCC CHECKDB found issues in database: TestDB - `$(`$_.Exception.Message)"
     }
     
     Write-Host "Post-migration tasks completed for database: TestDB" -ForegroundColor Green
@@ -444,14 +444,14 @@ Write-Host "Migration script completed for database: TestDB" -ForegroundColor Gr
         $content | Should -Match "Restore-DbaDatabase"
         $content | Should -Match "Set-DbaDbCompatibility"
         $content | Should -Match "Update-DbaStatistics"
-        $content | Should -Match "Invoke-DbaDbccCheckdb"
+        $content | Should -Match "Invoke-DbaQuery"
         
-        # Verify it does NOT contain T-SQL commands
+        # Verify it does NOT contain raw T-SQL commands (DBCC CHECKDB is now executed via Invoke-DbaQuery)
         $content | Should -Not -Match "BACKUP DATABASE \["
         $content | Should -Not -Match "RESTORE DATABASE \["
         $content | Should -Not -Match "ALTER DATABASE.*SET COMPATIBILITY_LEVEL"
         $content | Should -Not -Match "EXEC sp_updatestats"
-        $content | Should -Not -Match "DBCC CHECKDB\("
+        # Note: DBCC CHECKDB is now executed via Invoke-DbaQuery cmdlet, so it appears as a query string
         $content | Should -Not -Match "USE \[master\]"
         $content | Should -Not -Match "GO"
         


### PR DESCRIPTION
## Summary

Fixes runtime errors caused by non-existent dbatools cmdlet names. The user reported that `Invoke-DbaDbccCheckdb`, `Copy-DbaServerTrigger`, and `Copy-DbaServerRole` were not recognized.

**Changes made:**
- **DBCC CHECKDB**: Replaced `Invoke-DbaDbccCheckdb` (which doesn't exist in dbatools) with `Invoke-DbaQuery` executing the DBCC CHECKDB command directly. This affects runtime code, script generation templates, and tests.
- **Server Triggers**: Replaced `Copy-DbaServerTrigger` with `Copy-DbaInstanceTrigger` (dbatools uses "Instance" for server-level objects)
- **Copy-DbaServerRole**: NOT changed - this cmdlet exists in dbatools. The user's issue may be version-related.

## Review & Testing Checklist for Human

- [ ] **Verify `Copy-DbaServerRole` works in your environment** - I did not change this cmdlet as it exists in dbatools. If you still see errors, check your dbatools version (`Get-Module dbatools`)
- [ ] **Test DBCC CHECKDB execution** - The error handling changed from status-based (`$result.Status -eq "Success"`) to exception-based (try/catch with `-EnableException`). Run a post-upgrade task on a test database to verify integrity checks work correctly
- [ ] **Test server trigger migration** - Run a migration with `-IncludeTriggers` to verify `Copy-DbaInstanceTrigger` works with your dbatools version

**Recommended test plan:**
1. Run `Get-Command Copy-DbaInstanceTrigger, Copy-DbaServerRole, Invoke-DbaQuery -Module dbatools` to verify cmdlets exist
2. Test with `-WhatIf` mode first to see planned operations
3. Run a full migration on a test environment

### Notes
- All 67 Pester tests pass
- The DBCC CHECKDB query uses `WITH NO_INFOMSGS` to suppress informational messages

Link to Devin run: https://app.devin.ai/sessions/f044a9d1d7104fc98b0820200d35ca03
Requested by: karim_attaleb01@yahoo.fr (@karim-attaleb)