### PR TITLE
Fix: Correct Set-DbaDbCompatibility parameter name

### DIFF
--- a/Modules/SQLUpgrade.Migration.psm1
+++ b/Modules/SQLUpgrade.Migration.psm1
@@ -301,7 +301,7 @@ try {
     Write-Host "Running post-migration tasks for database: $DatabaseName" -ForegroundColor Yellow
     
     # Update database compatibility level to SQL Server 2022
-    Set-DbaDbCompatibility -SqlInstance `$targetConn -Database '$DatabaseName' -CompatibilityLevel 160
+    Set-DbaDbCompatibility -SqlInstance `$targetConn -Database '$DatabaseName' -Compatibility 160
     Write-Host "Updated compatibility level to SQL Server 2022 (160)" -ForegroundColor Cyan
     
     # Update statistics

--- a/Modules/SQLUpgrade.PostUpgrade.psm1
+++ b/Modules/SQLUpgrade.PostUpgrade.psm1
@@ -65,7 +65,7 @@ function Invoke-PostUpgradeTasks {
             # Update Database Compatibility Level
             Write-UpgradeLog -Message "Updating compatibility level for $dbName to SQL Server 2022" -LogFile $LogFile -ErrorLogFile $ErrorLogFile
             if (-not $WhatIfMode) {
-                Set-DbaDbCompatibility -SqlInstance $TargetConnection -Database $dbName -CompatibilityLevel 160 # SQL Server 2022
+                Set-DbaDbCompatibility -SqlInstance $TargetConnection -Database $dbName -Compatibility 160 # SQL Server 2022
             } else {
                 Write-UpgradeLog -Message "[WHATIF] Would update compatibility level for $dbName to 160" -LogFile $LogFile -ErrorLogFile $ErrorLogFile
             }

--- a/Start-SQLServerUpgrade.ps1
+++ b/Start-SQLServerUpgrade.ps1
@@ -326,7 +326,7 @@ try {
 }
 
 # Update compatibility level to SQL Server 2022 (160)
-Set-DbaDbCompatibility -SqlInstance `$targetConn -Database '$dbName' -CompatibilityLevel 160
+Set-DbaDbCompatibility -SqlInstance `$targetConn -Database '$dbName' -Compatibility 160
 Write-Host "Updated compatibility level for $dbName to SQL Server 2022" -ForegroundColor Cyan
 
 # Update statistics

--- a/Tests/SQLUpgrade.Tests.ps1
+++ b/Tests/SQLUpgrade.Tests.ps1
@@ -409,7 +409,7 @@ try {
     Write-Host "Running post-migration tasks for database: TestDB" -ForegroundColor Yellow
     
     # Update database compatibility level to SQL Server 2022
-    Set-DbaDbCompatibility -SqlInstance `$targetConn -Database 'TestDB' -CompatibilityLevel 160
+    Set-DbaDbCompatibility -SqlInstance `$targetConn -Database 'TestDB' -Compatibility 160
     Write-Host "Updated compatibility level to SQL Server 2022 (160)" -ForegroundColor Cyan
     
     # Update statistics


### PR DESCRIPTION
## Summary

Fixes the incorrect parameter name for `Set-DbaDbCompatibility` cmdlet. The parameter was incorrectly named `-CompatibilityLevel` but the actual dbatools parameter is `-Compatibility`.

Verified using:
```powershell
Get-Command Set-DbaDbCompatibility -Syntax
# Shows: -Compatibility <CompatibilityLevel>
```

Changed in 4 files:
- `Modules/SQLUpgrade.PostUpgrade.psm1` - runtime code
- `Modules/SQLUpgrade.Migration.psm1` - script generation template
- `Start-SQLServerUpgrade.ps1` - script generation template
- `Tests/SQLUpgrade.Tests.ps1` - test template

## Review & Testing Checklist for Human

- [ ] **Verify parameter name matches your dbatools version** - Run `Get-Command Set-DbaDbCompatibility -Syntax` to confirm `-Compatibility` is the correct parameter in your environment
- [ ] **Test post-upgrade tasks** - Run the script with a test database to verify compatibility level updates work without parameter errors

**Recommended test:**
```powershell
# Quick validation
Set-DbaDbCompatibility -SqlInstance 'YourInstance' -Database 'TestDB' -Compatibility 160 -WhatIf
```

### Notes
- All 67 Pester tests pass (though tests don't validate parameter names specifically)
- This is a simple rename with no logic changes

Link to Devin run: https://app.devin.ai/sessions/f044a9d1d7104fc98b0820200d35ca03
Requested by: karim_attaleb01@yahoo.fr (@karim-attaleb)