### PR TITLE
Make database migration optional with dbatools-style Exclude parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,27 @@ The solution is organized into the following modules:
 
 ### Complete Instance Migration (Default Behavior)
 
-**Complete Instance Migration - Everything except system/utility databases:**
+**Full Migration - All databases and all server objects (dbatools-style):**
 ```powershell
 # By default, migrates EVERYTHING for a complete instance upgrade:
-# ✅ All user databases (excludes system: master, model, msdb, tempdb)
-# ✅ All server objects: logins, jobs, linked servers, credentials, alerts, operators, etc.
-# ❌ Excludes utility databases (ReportServer, SSISDB, distribution) for safety
-# This is the recommended approach for complete SQL Server instance migrations
-.\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\PROD" -TargetInstance "SQL2022\PROD" -Databases "All" -WhatIf
+# - All user databases (excludes system: master, model, msdb, tempdb)
+# - All server objects: logins, jobs, linked servers, credentials, alerts, operators, etc.
+# - Excludes utility databases (ReportServer, SSISDB, distribution) for safety
+# No -Databases parameter needed - defaults to 'All'
+.\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\PROD" -TargetInstance "SQL2022\PROD" -WhatIf
+```
+
+**Server Objects Only - No database migration:**
+```powershell
+# Migrate only server objects (logins, jobs, linked servers, etc.) without touching databases
+# Use -Exclude 'Databases' to skip database migration entirely
+.\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\PROD" -TargetInstance "SQL2022\PROD" -Exclude 'Databases'
+```
+
+**Specific Databases Only:**
+```powershell
+# Migrate specific databases plus all server objects
+.\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\PROD" -TargetInstance "SQL2022\PROD" -Databases @("Database1", "Database2")
 ```
 
 **Include Utility Databases - For servers with SSRS/SSIS/Replication:**
@@ -68,16 +81,16 @@ The solution is organized into the following modules:
 # - SQL Server Integration Services (SSIS) - includes SSISDB database  
 # - SQL Server Replication - includes distribution database
 # - Data Quality Services (DQS) - includes DQS databases
-.\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\PROD" -TargetInstance "SQL2022\PROD" -Databases "All" -IncludeSupportDbs
+.\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\PROD" -TargetInstance "SQL2022\PROD" -IncludeSupportDbs
 ```
 
-**Server Object Exclusion - Fine-grained control:**
+**Exclude Specific Components - Fine-grained control:**
 ```powershell
-# Exclude specific server objects when you need granular control:
+# Exclude specific components when you need granular control:
 # - Exclude 'Logins' when you want to review/manage security separately
 # - Exclude 'AgentServer' when you want to prevent jobs from running immediately
 # - Exclude 'LinkedServers' when connection strings need updating for new environment
-.\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\PROD" -TargetInstance "SQL2022\PROD" -Databases "All" -Exclude 'Logins','AgentServer','LinkedServers'
+.\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\PROD" -TargetInstance "SQL2022\PROD" -Exclude 'Logins','AgentServer','LinkedServers'
 ```
 
 ### Basic Usage with WhatIf
@@ -85,9 +98,9 @@ The solution is organized into the following modules:
 .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Databases @("Database1", "Database2") -WhatIf
 ```
 
-### Complete Upgrade with All Databases
+### Complete Upgrade with Encryption Support
 ```powershell
-.\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Databases "All" -IncludeEncryption
+.\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -IncludeEncryption
 ```
 
 ### Using Individual Modules
@@ -110,12 +123,12 @@ $connection = Test-InstanceConnectivity -Instance "SQL2019\INSTANCE1" -LogFile $
 |-----------|------|----------|-------------|
 | `SourceInstance` | String | Yes | Source SQL Server instance name |
 | `TargetInstance` | String | Yes | Target SQL Server 2022 instance name |
-| `Databases` | String/Array | Yes | Database names to upgrade or "All" for all user databases |
+| `Databases` | String/Array | No | Database names to upgrade or "All". Defaults to "All" if not specified. Use `-Exclude 'Databases'` to skip database migration entirely. |
 | `IncludeEncryption` | Switch | No | Include encrypted objects and TDE databases |
 | `WhatIf` | Switch | No | Show what would be done without making changes |
 | `LogPath` | String | No | Path for log files (default: C:\Logs\SQLUpgrade) |
 | `IncludeSupportDbs` | Switch | No | Include utility databases (ReportServer, SSISDB, distribution, etc.) |
-| `Exclude` | String[] | No | Server objects to exclude from migration |
+| `Exclude` | String[] | No | Components to exclude from migration. By default, ALL components are migrated. Valid values: 'Databases', 'Logins', 'AgentServer', 'Credentials', 'LinkedServers', 'SpConfigure', 'SystemTriggers', 'BackupDevices', etc. |
 
 ## Database Migration Approach
 

--- a/Start-SQLServerUpgrade.ps1
+++ b/Start-SQLServerUpgrade.ps1
@@ -16,7 +16,9 @@
     Target SQL Server 2022 instance name
     
 .PARAMETER Databases
-    Array of database names to upgrade. Use 'All' for all user databases
+    Array of database names to upgrade. Use 'All' for all user databases.
+    If omitted and 'Databases' is not in -Exclude, defaults to 'All' (migrate all user databases).
+    If omitted and 'Databases' is in -Exclude, no databases are migrated (server objects only).
     
 .PARAMETER IncludeEncryption
     Include encrypted objects and TDE databases
@@ -45,42 +47,6 @@
 .PARAMETER LogBackupPaths
     Array of paths to existing log backup files
 
-.PARAMETER IncludeLogins
-    Migrate SQL Server logins (excluding system logins)
-
-.PARAMETER IncludeJobs
-    Migrate SQL Server Agent jobs
-
-.PARAMETER IncludeLinkedServers
-    Migrate linked servers
-
-.PARAMETER IncludeTriggers
-    Migrate server-level triggers
-
-.PARAMETER IncludeServerRoles
-    Migrate custom server roles
-
-.PARAMETER IncludeCredentials
-    Migrate credentials
-
-.PARAMETER IncludeProxyAccounts
-    Migrate SQL Server Agent proxy accounts
-
-.PARAMETER IncludeAlerts
-    Migrate SQL Server Agent alerts
-
-.PARAMETER IncludeOperators
-    Migrate SQL Server Agent operators
-
-.PARAMETER IncludeBackupDevices
-    Migrate backup devices
-
-.PARAMETER IncludeServerConfiguration
-    Migrate server configuration settings
-
-.PARAMETER IncludeAllServerObjects
-    Migrate all server-level objects (equivalent to enabling all individual switches)
-
 .PARAMETER Exclude
     Server objects to exclude from migration. Valid values:
     'Databases', 'Logins', 'AgentServer', 'Credentials', 'LinkedServers', 'SpConfigure', 
@@ -94,25 +60,36 @@
     Use this when migrating servers with SQL Server Reporting Services, Integration Services, or replication configured.
     
 .EXAMPLE
-    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Databases @("Database1", "Database2") -WhatIf
+    # Full migration (all databases and all server objects - default behavior)
+    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1"
     
 .EXAMPLE
-    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Databases "All" -IncludeEncryption
+    # Server objects only (no database migration)
+    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Exclude 'Databases'
 
 .EXAMPLE
-    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Databases "All" -IncludeAllServerObjects
+    # Specific databases only
+    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Databases @("Database1", "Database2")
 
 .EXAMPLE
-    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Databases "All" -IncludeLogins -IncludeJobs -IncludeLinkedServers
+    # Full migration with encryption support
+    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -IncludeEncryption
 
 .EXAMPLE
-    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Databases "All" -MigrationMethod BackupRestore -BackupPath "C:\Backups"
+    # Full migration excluding logins and Agent jobs
+    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Exclude 'Logins','AgentServer'
 
 .EXAMPLE
-    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Databases @("MyDB") -MigrationMethod BackupRestore -UseExistingBackups -FullBackupPath "C:\Backups\MyDB_Full.bak" -DifferentialBackupPath "C:\Backups\MyDB_Diff.bak" -LogBackupPaths @("C:\Backups\MyDB_Log1.trn", "C:\Backups\MyDB_Log2.trn")
+    # Backup/Restore migration method
+    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -MigrationMethod BackupRestore -BackupPath "C:\Backups"
 
 .EXAMPLE
-    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Databases "All" -IncludeSupportDbs -Exclude 'Logins','AgentServer'
+    # Restore from existing backups
+    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -Databases @("MyDB") -MigrationMethod BackupRestore -UseExistingBackups -FullBackupPath "C:\Backups\MyDB_Full.bak"
+
+.EXAMPLE
+    # Include utility databases (SSRS, SSIS, replication)
+    .\Start-SQLServerUpgrade.ps1 -SourceInstance "SQL2019\INSTANCE1" -TargetInstance "SQL2022\INSTANCE1" -IncludeSupportDbs
 #>
 
 [CmdletBinding(SupportsShouldProcess)]
@@ -123,9 +100,10 @@ param(
     [Parameter(Mandatory = $true)]
     [string]$TargetInstance,
     
-    [Parameter(Mandatory = $true)]
+    # Optional: Filter which databases to migrate. Defaults to 'All' if not specified.
+    # Use -Exclude 'Databases' to skip database migration entirely.
     [ValidateScript({
-        if ($_ -eq "All" -or ($_ -is [array] -and $_.Count -gt 0) -or ($_ -is [string] -and $_ -ne "")) {
+        if ($null -eq $_ -or $_ -eq "All" -or ($_ -is [array] -and $_.Count -gt 0) -or ($_ -is [string] -and $_ -ne "")) {
             $true
         } else {
             throw "Databases must be 'All' or an array of database names"
@@ -146,21 +124,8 @@ param(
     [string]$DifferentialBackupPath,
     [string[]]$LogBackupPaths,
     
-    # Server Object Migration Switches (enabled by default for complete instance migration)
-    [switch]$IncludeLogins = $true,
-    [switch]$IncludeJobs = $true,
-    [switch]$IncludeLinkedServers = $true,
-    [switch]$IncludeTriggers = $true,
-    [switch]$IncludeServerRoles = $true,
-    [switch]$IncludeCredentials = $true,
-    [switch]$IncludeProxyAccounts = $true,
-    [switch]$IncludeAlerts = $true,
-    [switch]$IncludeOperators = $true,
-    [switch]$IncludeBackupDevices = $true,
-    [switch]$IncludeServerConfiguration = $true,
-    [switch]$IncludeAllServerObjects,
-    
-    # Comprehensive exclusion parameter (alternative to individual switches)
+    # Exclusion parameter - use to skip specific components (dbatools-style)
+    # By default, ALL components are migrated. Use -Exclude to skip specific ones.
     [ValidateSet('Databases', 'Logins', 'AgentServer', 'Credentials', 'LinkedServers', 'SpConfigure', 'CentralManagementServer', 'DatabaseMail', 'SysDbUserObjects', 'SystemTriggers', 'BackupDevices', 'Audits', 'Endpoints', 'ExtendedEvents', 'PolicyManagement', 'ResourceGovernor', 'ServerAuditSpecifications', 'CustomErrors', 'DataCollector', 'StartupProcedures')]
     [string[]]$Exclude = @(),
     
@@ -180,6 +145,11 @@ Import-Module (Join-Path $ModulePath "SQLUpgrade.Encryption.psm1") -Force
 Import-Module (Join-Path $ModulePath "SQLUpgrade.Migration.psm1") -Force
 Import-Module (Join-Path $ModulePath "SQLUpgrade.PostUpgrade.psm1") -Force
 
+# Validate conflicting parameters
+if ($PSBoundParameters.ContainsKey('Databases') -and $Exclude -contains 'Databases') {
+    throw "You cannot specify -Databases and also exclude 'Databases' via -Exclude. Remove one of these parameters."
+}
+
 # Execute upgrade process using module functions only
 try {
     $logInfo = Initialize-UpgradeLogging -LogPath $LogPath
@@ -190,37 +160,46 @@ try {
     
     Test-CollationCompatibility -SourceConnection $sourceConnection -TargetConnection $targetConnection -LogFile $logInfo.LogFile -ErrorLogFile $logInfo.ErrorLogFile
     
-    # Get databases to process
-    $databasesToProcess = Get-UserDatabases -Connection $sourceConnection -DatabaseFilter $Databases -IncludeSupportDbs:$IncludeSupportDbs -LogFile $logInfo.LogFile -ErrorLogFile $logInfo.ErrorLogFile
+    # Build server object options based purely on -Exclude parameter (dbatools-style)
+    # By default, ALL server objects are migrated. Use -Exclude to skip specific ones.
+    $serverObjectOptions = @{
+        IncludeLogins             = ($Exclude -notcontains 'Logins')
+        IncludeJobs               = ($Exclude -notcontains 'AgentServer')
+        IncludeLinkedServers      = ($Exclude -notcontains 'LinkedServers')
+        IncludeTriggers           = ($Exclude -notcontains 'SystemTriggers')
+        IncludeServerRoles        = ($Exclude -notcontains 'Logins')
+        IncludeCredentials        = ($Exclude -notcontains 'Credentials')
+        IncludeProxyAccounts      = ($Exclude -notcontains 'AgentServer')
+        IncludeAlerts             = ($Exclude -notcontains 'AgentServer')
+        IncludeOperators          = ($Exclude -notcontains 'AgentServer')
+        IncludeBackupDevices      = ($Exclude -notcontains 'BackupDevices')
+        IncludeServerConfiguration = ($Exclude -notcontains 'SpConfigure')
+    }
     
-    # Migrate server objects first (if requested and not excluded)
-    $shouldMigrateServerObjects = ($IncludeAllServerObjects -or $IncludeLogins -or $IncludeJobs -or $IncludeLinkedServers -or $IncludeTriggers -or $IncludeServerRoles -or $IncludeCredentials -or $IncludeProxyAccounts -or $IncludeAlerts -or $IncludeOperators -or $IncludeBackupDevices -or $IncludeServerConfiguration) -and ($Exclude -notcontains 'Logins' -and $Exclude -notcontains 'AgentServer' -and $Exclude -notcontains 'LinkedServers' -and $Exclude -notcontains 'Credentials')
+    # Migrate server objects if any are enabled
+    $shouldMigrateServerObjects = $serverObjectOptions.Values -contains $true
     
     if ($shouldMigrateServerObjects) {
-        $serverObjectOptions = @{
-            IncludeLogins = ($IncludeLogins -or $IncludeAllServerObjects) -and ($Exclude -notcontains 'Logins')
-            IncludeJobs = ($IncludeJobs -or $IncludeAllServerObjects) -and ($Exclude -notcontains 'AgentServer')
-            IncludeLinkedServers = ($IncludeLinkedServers -or $IncludeAllServerObjects) -and ($Exclude -notcontains 'LinkedServers')
-            IncludeTriggers = ($IncludeTriggers -or $IncludeAllServerObjects) -and ($Exclude -notcontains 'SystemTriggers')
-            IncludeServerRoles = ($IncludeServerRoles -or $IncludeAllServerObjects) -and ($Exclude -notcontains 'Logins')
-            IncludeCredentials = ($IncludeCredentials -or $IncludeAllServerObjects) -and ($Exclude -notcontains 'Credentials')
-            IncludeProxyAccounts = ($IncludeProxyAccounts -or $IncludeAllServerObjects) -and ($Exclude -notcontains 'AgentServer')
-            IncludeAlerts = ($IncludeAlerts -or $IncludeAllServerObjects) -and ($Exclude -notcontains 'AgentServer')
-            IncludeOperators = ($IncludeOperators -or $IncludeAllServerObjects) -and ($Exclude -notcontains 'AgentServer')
-            IncludeBackupDevices = ($IncludeBackupDevices -or $IncludeAllServerObjects) -and ($Exclude -notcontains 'BackupDevices')
-            IncludeServerConfiguration = ($IncludeServerConfiguration -or $IncludeAllServerObjects) -and ($Exclude -notcontains 'SpConfigure')
-        }
-        
         Write-UpgradeLog -Message "Server object migration options: $(($serverObjectOptions.GetEnumerator() | Where-Object { $_.Value } | ForEach-Object { $_.Key }) -join ', ')" -LogFile $logInfo.LogFile -ErrorLogFile $logInfo.ErrorLogFile
         
         Copy-ServerObjects -SourceConnection $sourceConnection -TargetConnection $targetConnection -ServerObjectOptions $serverObjectOptions -WhatIfMode:$WhatIf -LogFile $logInfo.LogFile -ErrorLogFile $logInfo.ErrorLogFile
     } else {
-        Write-UpgradeLog -Message "Server object migration skipped (excluded or not requested)" -LogFile $logInfo.LogFile -ErrorLogFile $logInfo.ErrorLogFile
+        Write-UpgradeLog -Message "Server object migration skipped (all server objects excluded)" -LogFile $logInfo.LogFile -ErrorLogFile $logInfo.ErrorLogFile
     }
     
     # Migrate databases (if not excluded)
     $processedDatabases = @()
     if ($Exclude -notcontains 'Databases') {
+        # Determine effective database filter: use provided value or default to 'All'
+        $effectiveDatabaseFilter = if ($PSBoundParameters.ContainsKey('Databases')) {
+            $Databases
+        } else {
+            'All'
+        }
+        
+        # Get databases to process (only when databases are NOT excluded)
+        $databasesToProcess = Get-UserDatabases -Connection $sourceConnection -DatabaseFilter $effectiveDatabaseFilter -IncludeSupportDbs:$IncludeSupportDbs -LogFile $logInfo.LogFile -ErrorLogFile $logInfo.ErrorLogFile
+        
         Write-UpgradeLog -Message "Starting database migration for $($databasesToProcess.Count) databases" -LogFile $logInfo.LogFile -ErrorLogFile $logInfo.ErrorLogFile
         
         foreach ($database in $databasesToProcess) {

--- a/Tests/SQLUpgrade.Tests.ps1
+++ b/Tests/SQLUpgrade.Tests.ps1
@@ -308,19 +308,21 @@ Describe "Main Script Integration Tests" {
             $script:MainScriptContent | Should -Match "\`$LogPath"
         }
         
-        It "Should have server object migration parameters" {
-            $script:MainScriptContent | Should -Match "\`$IncludeLogins"
-            $script:MainScriptContent | Should -Match "\`$IncludeJobs"
-            $script:MainScriptContent | Should -Match "\`$IncludeLinkedServers"
-            $script:MainScriptContent | Should -Match "\`$IncludeTriggers"
-            $script:MainScriptContent | Should -Match "\`$IncludeServerRoles"
-            $script:MainScriptContent | Should -Match "\`$IncludeCredentials"
-            $script:MainScriptContent | Should -Match "\`$IncludeProxyAccounts"
-            $script:MainScriptContent | Should -Match "\`$IncludeAlerts"
-            $script:MainScriptContent | Should -Match "\`$IncludeOperators"
-            $script:MainScriptContent | Should -Match "\`$IncludeBackupDevices"
-            $script:MainScriptContent | Should -Match "\`$IncludeServerConfiguration"
-            $script:MainScriptContent | Should -Match "\`$IncludeAllServerObjects"
+        It "Should have Exclude parameter for dbatools-style component exclusion" {
+            # dbatools-style: ALL components migrated by default, use -Exclude to skip specific ones
+            $script:MainScriptContent | Should -Match "\`$Exclude"
+            $script:MainScriptContent | Should -Match "ValidateSet.*'Databases'.*'Logins'.*'AgentServer'"
+        }
+        
+        It "Should have optional Databases parameter" {
+            # Databases parameter should NOT be mandatory (dbatools-style)
+            $script:MainScriptContent | Should -Not -Match "\[Parameter\(Mandatory = \`$true\)\]\s*\[ValidateScript.*\`$Databases"
+        }
+        
+        It "Should build serverObjectOptions from Exclude parameter" {
+            # Server object options should be derived purely from -Exclude
+            $script:MainScriptContent | Should -Match "IncludeLogins\s*=\s*\(\`$Exclude -notcontains 'Logins'\)"
+            $script:MainScriptContent | Should -Match "IncludeJobs\s*=\s*\(\`$Exclude -notcontains 'AgentServer'\)"
         }
         
         It "Should call module functions only" {

--- a/Usage-Examples.ps1
+++ b/Usage-Examples.ps1
@@ -129,21 +129,31 @@ Write-UpgradeLog -Message "Test message" -Level "Information" -LogFile `$logInfo
 Get-Command -Module SQLUpgrade.Logging
 "@
 
-Write-Host "`nExample 10: Complete instance migration (default behavior) - Comprehensive upgrade" -ForegroundColor Green
+Write-Host "`nExample 10: Complete instance migration (default behavior - dbatools-style)" -ForegroundColor Green
 Write-Host "# By default, migrates EVERYTHING for a complete instance upgrade:"
-Write-Host "# ✅ All user databases (excludes system: master, model, msdb, tempdb)"
-Write-Host "# ✅ All server objects: logins, jobs, linked servers, credentials, alerts, operators, etc."
-Write-Host "# ❌ Excludes utility databases (ReportServer, SSISDB, distribution) for safety"
-Write-Host "# This is the recommended approach for complete SQL Server instance migrations"
+Write-Host "# - All user databases (excludes system: master, model, msdb, tempdb)"
+Write-Host "# - All server objects: logins, jobs, linked servers, credentials, alerts, operators, etc."
+Write-Host "# - Excludes utility databases (ReportServer, SSISDB, distribution) for safety"
+Write-Host "# No -Databases parameter needed - defaults to 'All' (dbatools-style)"
+Write-Host @"
+.\Start-SQLServerUpgrade.ps1 `
+    -SourceInstance "SQL2019\PROD" `
+    -TargetInstance "SQL2022\PROD"
+"@
+
+Write-Host "`nExample 11: Server objects only - No database migration" -ForegroundColor Green
+Write-Host "# Migrate only server objects (logins, jobs, linked servers, etc.) without touching databases"
+Write-Host "# Use -Exclude 'Databases' to skip database migration entirely"
+Write-Host "# Useful when you only need to sync server-level configuration"
 Write-Host @"
 .\Start-SQLServerUpgrade.ps1 `
     -SourceInstance "SQL2019\PROD" `
     -TargetInstance "SQL2022\PROD" `
-    -Databases "All"
+    -Exclude 'Databases'
 "@
 
-Write-Host "`nExample 11: Exclude specific server objects for granular control" -ForegroundColor Green
-Write-Host "# Exclude specific server objects when you need granular control:"
+Write-Host "`nExample 12: Exclude specific components for granular control" -ForegroundColor Green
+Write-Host "# Exclude specific components when you need granular control:"
 Write-Host "# - Exclude 'Logins' when you want to review/manage security separately"
 Write-Host "# - Exclude 'AgentServer' when you want to prevent jobs from running immediately"
 Write-Host "# - Exclude 'LinkedServers' when connection strings need updating for new environment"
@@ -151,11 +161,10 @@ Write-Host @"
 .\Start-SQLServerUpgrade.ps1 `
     -SourceInstance "SQL2019\PROD" `
     -TargetInstance "SQL2022\PROD" `
-    -Databases "All" `
     -Exclude 'Logins','AgentServer','LinkedServers'
 "@
 
-Write-Host "`nExample 12: Include utility databases for servers with SSRS/SSIS/Replication" -ForegroundColor Green
+Write-Host "`nExample 13: Include utility databases for servers with SSRS/SSIS/Replication" -ForegroundColor Green
 Write-Host "# Include ReportServer, SSISDB, distribution databases when migrating servers with:"
 Write-Host "# - SQL Server Reporting Services (SSRS) - includes ReportServer databases"
 Write-Host "# - SQL Server Integration Services (SSIS) - includes SSISDB database"
@@ -165,7 +174,6 @@ Write-Host @"
 .\Start-SQLServerUpgrade.ps1 `
     -SourceInstance "SQL2019\PROD" `
     -TargetInstance "SQL2022\PROD" `
-    -Databases "All" `
     -IncludeSupportDbs
 "@
 


### PR DESCRIPTION
# Make database migration optional with dbatools-style Exclude parameter

## Summary

This PR refactors the parameter interface to follow the dbatools `Start-DbaMigration` pattern, addressing the "fundamental flaw" where database migration was mandatory even when users only wanted to migrate server objects.

**Breaking Changes:**
- Removed all `-Include*` switches (`-IncludeLogins`, `-IncludeJobs`, `-IncludeLinkedServers`, `-IncludeTriggers`, `-IncludeServerRoles`, `-IncludeCredentials`, `-IncludeProxyAccounts`, `-IncludeAlerts`, `-IncludeOperators`, `-IncludeBackupDevices`, `-IncludeServerConfiguration`)
- Removed `-IncludeAllServerObjects` switch
- `-Databases` parameter is now optional (was mandatory)

**New Behavior:**
- By default, ALL components are migrated (databases + server objects)
- Use `-Exclude` to skip specific components (e.g., `-Exclude 'Databases'` for server-objects-only migration)
- `-Databases` defaults to `'All'` when not specified
- Throws error if both `-Databases` and `-Exclude 'Databases'` are specified (conflicting intent)

Key fix: `Get-UserDatabases` is now only called when databases are NOT excluded, fixing the original issue where database enumeration happened unconditionally.

## Review & Testing Checklist for Human

- [ ] **Verify breaking change is acceptable**: Existing scripts using `-IncludeLogins`, `-IncludeJobs`, etc. will fail. Confirm no external consumers depend on these parameters.
- [ ] **Test server-objects-only migration**: Run `.\Start-SQLServerUpgrade.ps1 -SourceInstance "..." -TargetInstance "..." -Exclude 'Databases'` and verify no database operations occur
- [ ] **Test default behavior**: Run without `-Databases` parameter and verify all databases are migrated
- [ ] **Test conflict detection**: Verify error is thrown when both `-Databases @("DB1")` and `-Exclude 'Databases'` are specified
- [ ] **Test with real SQL Server instances**: The Pester tests (66 passing) don't connect to actual SQL Server - manual testing against real instances is required before production use

**Recommended test plan:**
1. Set up two SQL Server instances (source/target)
2. Test: `.\Start-SQLServerUpgrade.ps1 -SourceInstance "..." -TargetInstance "..." -WhatIf` (should show all DBs + all server objects)
3. Test: `.\Start-SQLServerUpgrade.ps1 -SourceInstance "..." -TargetInstance "..." -Exclude 'Databases' -WhatIf` (should show only server objects)
4. Test: `.\Start-SQLServerUpgrade.ps1 -SourceInstance "..." -TargetInstance "..." -Databases @("TestDB") -WhatIf` (should show specific DB + all server objects)

### Notes

- This follows the dbatools `Start-DbaMigration.ps1` pattern as requested by the user
- The `serverObjectOptions` mapping ties `IncludeServerRoles` to `'Logins'` exclusion and multiple Agent-related options to `'AgentServer'` exclusion - this mirrors dbatools behavior

Link to Devin run: https://app.devin.ai/sessions/f044a9d1d7104fc98b0820200d35ca03
Requested by: karim_attaleb01@yahoo.fr (@karim-attaleb)